### PR TITLE
Update to Go 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/mit-pdos/go-nfsd/actions/workflows/build.yml/badge.svg)](https://github.com/mit-pdos/go-nfsd/actions/workflows/build.yml)
 
+This repository requires **Go 1.23** or later to build.
+
 An NFSv3 server that uses [GoJournal](https://github.com/mit-pdos/go-journal) to
 write operations atomically to disk. Unlike many other NFS servers, GoNFS
 implements the file-system abstraction on top of a disk (which can be any file,

--- a/artifact/vm-setup.sh
+++ b/artifact/vm-setup.sh
@@ -132,8 +132,8 @@ sudo apt-get install -y gnuplot-nox
 
 # Install Go and Go dependencies
 
-GO_FILE=go1.16.4.linux-amd64.tar.gz
-wget https://golang.org/dl/$GO_FILE
+GO_FILE=go1.23.8.linux-amd64.tar.gz
+wget https://go.dev/dl/$GO_FILE
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf $GO_FILE
 rm $GO_FILE
 # shellcheck disable=2016

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mit-pdos/go-nfsd
 
-go 1.22
+go 1.23
 
 require (
 	github.com/goose-lang/goose v0.7.1


### PR DESCRIPTION
## Summary
- update module to Go 1.23
- bump VM setup script to download Go 1.23.8
- document new minimum Go version in README

## Testing
- `go fmt ./...`
- ❌ `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*